### PR TITLE
Hide low risk chart

### DIFF
--- a/frontend/components/AreaChart.js
+++ b/frontend/components/AreaChart.js
@@ -101,10 +101,8 @@ const AreaChart = ({ data }) => {
           {lineSegments.map((segment, i) => (
             <path
               key={i}
-              className="chart-line"
+              className={styles.line}
               stroke={getRiskColor(data[i].riskLevel)}
-              strokeWidth="3"
-              fill="transparent"
               d={segment}
             ></path>
           ))}

--- a/frontend/components/Footer.js
+++ b/frontend/components/Footer.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import styles from "/styles/Footer.module.css";
+import Link from "next/link";
 
 const data = {
   links: [
@@ -61,9 +62,11 @@ const logos = data.logos.map((logo, i) => (
 ));
 
 const links = data.links.map((link, i) => (
-  <a href={link.permalink} key={i} className={styles.link}>
-    <div className={styles.linktext}>{link.text}</div>
-  </a>
+  <Link href={link.permalink} key={i} prefetch={false}>
+    <a className={styles.link}>
+      <div className={styles.linktext}>{link.text}</div>
+    </a>
+  </Link>
 ));
 
 const Footer = () => {

--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -22,7 +22,11 @@ const links = [
 ];
 
 const Header = () => {
-  const { buttonProps, itemProps, isOpen } = useDropdownMenu(links.length);
+  const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(links.length);
+
+  function closeMenu() {
+    setIsOpen(false);
+  }
 
   return (
     <div className={styles.header}>
@@ -41,9 +45,9 @@ const Header = () => {
             <Icon name="bars" />
           </button>
           <div className={`${styles.menu} ${isOpen ? styles.menuopen : ""}`} role="menu">
-            {links.map((link) => (
+            {links.map((link, i) => (
               <Link key={link.permalink} prefetch={false} href={link.permalink}>
-                <a>{link.text}</a>
+                <a onClick={closeMenu}>{link.text}</a>
               </Link>
             ))}
           </div>

--- a/frontend/components/RiskHours.js
+++ b/frontend/components/RiskHours.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import Link from "next/link";
+import { useState, useEffect } from "react";
 
 import AreaChart from "/components/AreaChart";
 import Risk from "/components/Risk";
@@ -7,29 +8,52 @@ import styles from "/styles/RiskHours.module.css";
 import riskDefinitions from "/content/riskDefinitions";
 
 const RiskHours = ({ hours, riskLevel }) => {
-  const riskSlug = riskDefinitions[riskLevel].slug;
+  const [chartVisible, setChartVisible] = useState(false);
+  const toggleChart = () => {
+    setChartVisible(!chartVisible);
+  };
+
+  const generateRiskMessage = (riskLevel) => {
+    const riskSlug = riskDefinitions[riskLevel].slug;
+
+    if (riskLevel === 0) {
+      return (
+        <span>
+          {riskDefinitions[riskLevel].text} risk for the next 24 hours.{" "}
+          <button onClick={toggleChart} className={styles.showChart}>
+            {chartVisible ? "Hide" : "Show"}&nbsp;chart
+          </button>
+        </span>
+      );
+    } else {
+      return (
+        <span>
+          Sitka will experience {riskDefinitions[riskLevel].text.toLowerCase()} landslide risk
+          within the next 24 hours.{" "}
+          <Link prefetch={false} href={`/prepare/#${riskSlug}`}>
+            <a className={styles.prepare}> How to prepare</a>
+          </Link>
+        </span>
+      );
+    }
+  };
+
+  const riskMessage = generateRiskMessage(riskLevel);
 
   return (
     <section className={styles.section}>
       <div className={styles.header}>
         <h2 className={styles.title}>24 hour forecast</h2>
         <p className={styles.message}>
-          {riskLevel !== 0 && <Risk riskLevel={riskLevel} hasText={false} />}
-          <span>
-            Sitka will experience {riskDefinitions[riskLevel].text.toLowerCase()} risk within the
-            next 24 hours.
-            {riskLevel !== 0 && (
-              <span>
-                <Link prefetch={false} href={`/prepare/#${riskSlug}`}>
-                  <a className={styles.prepare}> Learn how to prepare</a>
-                </Link>
-                .
-              </span>
-            )}
-          </span>
+          <Risk riskLevel={riskLevel} hasText={false} />
+          {riskMessage}
         </p>
       </div>
-      <AreaChart data={hours} />
+      {(chartVisible || riskLevel !== 0) && (
+        <div className={styles.chartContainer}>
+          <AreaChart data={hours} />
+        </div>
+      )}
     </section>
   );
 };

--- a/frontend/styles/AreaChart.module.css
+++ b/frontend/styles/AreaChart.module.css
@@ -1,11 +1,15 @@
 .chart {
   position: relative;
-  width: 100%;
+  width: auto;
   height: 150px;
+  /*  margin: 0 calc(-1 * var(--space-200));
+  padding: var(--space-300) var(--space-200);*/
+  border-top: var(--gray-400) 1px solid;
 }
 
 @media screen and (min-width: 600px) {
   .chart {
+    border-top: none;
     height: 260px;
   }
 }
@@ -48,10 +52,14 @@
   shape-rendering: crispEdges;
 }
 
+.line {
+  stroke-width: 6;
+  fill: transparent;
+}
+
 .lineY {
-  stroke: var(--gray-500);
+  stroke: var(--gray-900);
   stroke-width: 1;
-  shape-rendering: crispEdges;
 }
 
 .lineY:last-of-type {

--- a/frontend/styles/AreaChart.module.css
+++ b/frontend/styles/AreaChart.module.css
@@ -2,8 +2,6 @@
   position: relative;
   width: auto;
   height: 150px;
-  /*  margin: 0 calc(-1 * var(--space-200));
-  padding: var(--space-300) var(--space-200);*/
   border-top: var(--gray-400) 1px solid;
 }
 

--- a/frontend/styles/RiskDays.module.css
+++ b/frontend/styles/RiskDays.module.css
@@ -118,11 +118,14 @@
 		padding: var(--space-300) var(--space-300);
 	}
 
-	.categoryName {
-	}
-
 	.section {
 		margin: 0 0 var(--space-400);
 		padding: 0;
+	}
+}
+
+@media screen and (min-width: 600px) and (prefers-color-scheme: dark) {
+	.category {
+		background: var(--gray-500);
 	}
 }

--- a/frontend/styles/RiskHours.module.css
+++ b/frontend/styles/RiskHours.module.css
@@ -1,17 +1,20 @@
 .section {
 	border-radius: var(--radius-500);
-	padding: 0 var(--space-200) var(--space-300);
+	padding: 0 var(--space-200) 0;
 	background-color: var(--background);
 	margin: 0 var(--space-200) var(--space-300);
 }
 
 .header {
-	border-bottom: var(--gray-400) 1px solid;
 	text-align: left;
 	color: inherit;
 	margin: 0 calc(-1 * var(--space-200));
 	padding: var(--space-300) var(--space-200);
 	align-items: center;
+}
+
+.chartContainer {
+	padding-bottom: var(--space-300);
 }
 
 .message {
@@ -26,8 +29,26 @@
 	margin-bottom: var(--space-200);
 }
 
+.showChart {
+	font-size: var(--size-500);
+	/* Adding padding to give button a larger click area, while using
+		 negative margin to not impact layout */
+	margin: -20px;
+	padding: 20px;
+	background: none;
+	text-decoration: underline;
+	color: inherit;
+	border: none;
+	text-align: left;
+	/* Defining a fixed width to prevent layout shift when 
+	   text switches from "Show chart" to "Hide chart" */
+	width: 5.2em;
+	box-sizing: content-box;
+}
+
 .prepare {
 	margin-top: var(--space-100);
+	/*font-weight: var(--weight-heavy);*/
 }
 
 @media screen and (min-width: 600px) {

--- a/frontend/styles/RiskHours.module.css
+++ b/frontend/styles/RiskHours.module.css
@@ -48,7 +48,6 @@
 
 .prepare {
 	margin-top: var(--space-100);
-	/*font-weight: var(--weight-heavy);*/
 }
 
 @media screen and (min-width: 600px) {

--- a/frontend/styles/variables.css
+++ b/frontend/styles/variables.css
@@ -9,7 +9,7 @@
   --heading: #111;
   --text: #333;
   --background: #fff;
-  --link: #2667d9;
+  --link: #06c;
   --background-accent: #edeff1;
   --detail-chevron: var(--gray-900);
   --page-header: var(--gray-300);

--- a/frontend/styles/variables.css
+++ b/frontend/styles/variables.css
@@ -40,8 +40,8 @@
   --space-200: 8px;
   --space-100: 4px;
 
-  --size-900: 36px;
-  --size-800: 21px;
+  --size-900: 38px;
+  --size-800: 20px;
   --size-700: 18px;
   --size-600: 16px;
   --size-500: 14px;
@@ -76,11 +76,11 @@
 
 @media screen and (min-width: 600px) {
   :root {
-    --size-900: 36px;
-    --size-800: 24px;
-    --size-700: 21px;
+    --size-900: 44px;
+    --size-800: 28px;
+    --size-700: 23px;
     --size-600: 18px;
-    --size-500: 16px;
+    --size-500: 15px;
 
     --space-900: 45px;
     --space-800: 40px;
@@ -96,14 +96,14 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --darkblue: #161616;
+    --darkblue: #141414;
     --mediumblue: var(--background);
     --risk0: #63d7bb;
-    --risk1: #d7a963;
-    --risk2: #d763a2;
+    --risk1: #d7bb63;
+    --risk2: #d76380;
     --heading: #fbfbfe;
     --text: #cfcfd8;
-    --background: #252525;
+    --background: #1e1e1e;
     --link: #74a9f6;
     --background-accent: var(--darkblue);
     --background-content: var(--background);
@@ -135,6 +135,6 @@
 
 @media screen and (min-width: 600px) and (prefers-color-scheme: dark) {
   :root {
-    --background: #1f1f1f;
+    /*--background: #1c1e20;*/
   }
 }


### PR DESCRIPTION
## Overview

This came up on a recent client call. When landslide risk is low, the 24 hour forecast chart is less interesting. If there is 0% probability, the chart shows a horizontal green line at the bottom of the chart, which can look confusing. And if risk is low, we can give users a simpler, calmer view by hiding the chart by default.

### Demo

<img width="369" alt="Screen Shot 2022-04-20 at 9 49 16 AM" src="https://user-images.githubusercontent.com/1809908/164246141-0867957b-838a-4310-a0a6-dcfbc6f1f66c.png">

<img width="369" alt="Screen Shot 2022-04-20 at 9 49 24 AM" src="https://user-images.githubusercontent.com/1809908/164246151-9bbd1d08-e732-4250-8a53-cdd2579df0f5.png">

<img width="369" alt="Screen Shot 2022-04-20 at 9 53 34 AM" src="https://user-images.githubusercontent.com/1809908/164246307-0b4b41db-5f8b-4e6f-a13c-81fdff9dff9f.png">

## Testing Instructions

 * Look at homepage with low 24 hour risk; the chart should be hidden by default
 * You should be able to expand the chart
 * Now look at the homepage with medium and high 24 hour risk; the chart should be visible by default

## Checklist

- [x] `./scripts/lint` runs without errors

