### PR TITLE
Scale risk in charts by low/med/high rating

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 
 // For debugging: a multiplier applied to rainfall amounts to get the results up into an
 // interesting range. Something in the 8-15 range will usually do the trick.
-const EXAGGERATION_FACTOR = 1;
+const EXAGGERATION_FACTOR = process.env.EXAGGERATION_FACTOR || 1;
 
 const MESOWEST_API = "https://api.synopticdata.com/v2";
 const MESOWEST_TOKEN = process.env.MESOWEST_TOKEN || "78b6412c25ea43beb10aa5399dd6fdfa";

--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -86,6 +86,21 @@ function landslideRisk(rainfall) {
   }
 }
 
+// For the charts that show a continuous scale, we want the low/med/high progression to make
+// visual sense, i.e. for Low to cover one third, Med to cover the middle third, etc.
+// To make that work, we need to map the calculated probablity onto a range representing where on
+// low/medium/high risk spectrum it falls.
+function normalizedRiskNum(rainfall) {
+  const prob = landslideProbability(rainfall);
+  if (prob <= 0.01) {
+    return prob / 0.01 / 3;
+  } else if (prob <= 0.7) {
+    return 1 / 3 + (prob - 0.01) / (0.7 - 0.01) / 3;
+  } else {
+    return 2 / 3 + (prob - 0.7) / 0.3 / 3;
+  }
+}
+
 // Download observed 3hr rainfall total at the Sitka airport weather station over the past 6 hours
 async function getPastRainfall() {
   const mesoResponse = await axios
@@ -120,7 +135,7 @@ async function getPastRainfall() {
     precipInches: mmToInches(precip),
     riskPrecip: riskPrecip,
     riskPrecipInches: mmToInches(riskPrecip),
-    riskProb: round(landslideProbability(riskPrecip), 4),
+    riskProb: round(normalizedRiskNum(riskPrecip), 4),
     riskLevel: landslideRisk(riskPrecip),
   };
 }
@@ -167,7 +182,7 @@ async function getForecastRainfall(observed) {
       datetimeLabel: toDatetimeLabel(forecast.timestamp),
       riskPrecip,
       riskPrecipInches: mmToInches(riskPrecip),
-      riskProb: round(landslideProbability(riskPrecip), 4),
+      riskProb: round(normalizedRiskNum(riskPrecip), 4),
       riskLevel: landslideRisk(riskPrecip),
     };
   });


### PR DESCRIPTION
## Overview

The linear low/med/high scale looks weird when we just the modeled probability of a landslide on it, because the breakpoints for what percentage probability translates to each risk level are 1% and 70%. So especially the medium-risk points will often show up below the middle of the scale if we just plot probability.

This changes the `riskProb` value to scale the numerical rating differently within each range, so for low-risk predictions it shows where the value falls between 0 and 1%, for medium-risk it shows where it falls between 1% and 70%, etc.  I reused the `riskProb` field name rather than making a new one because we only use it in two places, and we want the new behavior in both those places, and I couldn't really think of a better name anyway.

Resolves #19

### Demo

Main page chart: 
![image](https://user-images.githubusercontent.com/6598836/165366698-70001ed8-9f67-41d9-abb6-c088a848535e.png)

A few examples from the detail page:
![image](https://user-images.githubusercontent.com/6598836/165366737-a7a5f45c-536c-4c2c-8586-353f8d2f4f6b.png)

![image](https://user-images.githubusercontent.com/6598836/165366789-7dde95c8-4b3d-4c72-8164-b764d4828467.png)

![image](https://user-images.githubusercontent.com/6598836/165366804-323c54b8-6788-4c4d-9937-f12376827174.png)

### Notes

- This also includes a small change to the `EXAGGERATION_FACTOR` debugging constant in `getRainfall.js`: it will look for a value from the environment then fall back to 1 (i.e. using unmodified values) if there isn't one.  That means you can run e.g.
  ```
  EXAGGERATION_FACTOR=20 yarn run get-data
  ```
  (from in `frontend/`) to produce a `rainfall.json` file with that factor applied without having to modify the file.  Then you can see the new values by reloading the page (sometimes it seems to update automatically for me, but more often not :shrug:).
- I'm pointing this PR at the branch from PR #28 just so it shows the more up-to-date design, but it's functionally independent of those changes.  I'll rebase to develop before merging.

## Testing Instructions

- View the 24hr graph on the main page and the low/med/high bar on the detail page with different rainfall/risk values.
- It still won't move linearly with rainfall amount, but there shouldn't be any weird jumps where a tiny change in rainfall causes a big change in where the value falls on the charts.
- The plotted risk should always fall within the rated range--i.e. there should be no values that are labeled "Medium" but show up in the "Low" range on the chart, or any other mismatch.

## Checklist

- [x] `./scripts/lint` runs without errors

