### PR TITLE
Only show 3 days (today, tomorrow, day after) of forecast

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -37,6 +37,23 @@ function toShortTimestamp(isoTimestamp) {
   return ts.substring(0, 16);
 }
 
+// Returns a DateTime for the end of the third day from now (in Sitka time)
+// Note: This only gets used once, so it could be inline, but making it self-contained and
+// putting it with the other datetime-related functions seemed nicer.
+function calculateEndOfThirdDay() {
+  const twoDaysHence = DateTime.now({ zome: "America/Sitka" }).plus({ days: 2 });
+  return DateTime.fromObject(
+    {
+      year: twoDaysHence.year,
+      month: twoDaysHence.month,
+      day: twoDaysHence.day,
+      hour: 23,
+      minute: 59,
+    },
+    { zone: "America/Sitka" }
+  );
+}
+
 // Utility function to log errors Axios errors.
 function logRequestError(error) {
   console.log("==== ERROR ====");
@@ -213,8 +230,9 @@ function composeTwentyFourHours(forecasts) {
 
 function composeThreeDays(forecasts) {
   // Get all the hourly forecasts for the next three days
+  const endOfThirdDay = calculateEndOfThirdDay();
   const hours = forecasts
-    .filter((f) => DateTime.fromISO(f.timestamp) <= DateTime.now().plus({ days: 3 }))
+    .filter((f) => DateTime.fromISO(f.timestamp) <= endOfThirdDay)
     .map((f) => {
       return {
         ...f,


### PR DESCRIPTION
## Overview

The forecast was showing all the 3-hour periods within 72 hours of now. Which is one definition of "3 days", but we want to use a different definition--today, tomorrow, and the next day. This changes the datetime filter in the getRainfall script to that.

Resolves #25

### Demo

![image](https://user-images.githubusercontent.com/6598836/165957721-eeeefc0a-a45f-4541-bea5-2b15ef41fa39.png)
Before this PR, there would also be a "Monday" section that included the 1am-4am forecast.

### Notes

- This part of a PR daisy-chain, so the branch also includes everything in PR #32.

## Testing Instructions

It's a little tricky to exercise this a lot, since we don't have a way to mess with the time.  But fortunately any actual time you're likely to try the script will be partway through a day, so you'll be able to see the results.  It should include the entirety of the third day (the 1AM to 10PM forecast windows) but none of the fourth.

## Checklist

- [x] `./scripts/lint` runs without errors

