### PR TITLE
Add weather alert lookup to data fetching script

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -207,14 +207,32 @@ async function getForecastRainfall(observed) {
 }
 
 // Get current weather advisory status
-// TODO (#16): implement this. currently it's just a placeholder.
-// Note: This shouldn't block an update, so if the API call fails it should return a
-//       valid object with {active: false}.
+// Note: We don't want an error here to block an update, so if the API call fails it just
+//       returns a valid object with {active: false}.
 async function getWeatherAdvisory() {
-  return {
+  const lat = 57.053;
+  const lon = -135.36;
+  const defaultResult = {
     active: false,
-    permalink: "https://forecast.weather.gov/MapClick.php?lat=57.052&lon=-135.334",
+    permalink: `https://forecast.weather.gov/MapClick.php?lat=${lat}&lon=${lon}`,
   };
+  return axios
+    .get(
+      `https://api.weather.gov/alerts/active?status=actual&message_type=alert&point=${lat},${lon}`,
+      {
+        headers: { "User-Agent": NWS_USERAGENT },
+      }
+    )
+    .then((nwsResponse) => {
+      return {
+        ...defaultResult,
+        active: nwsResponse?.data?.features?.length > 0,
+      };
+    })
+    .catch((error) => {
+      logRequestError(error);
+      return defaultResult;
+    });
 }
 
 function composeTwentyFourHours(forecasts) {


### PR DESCRIPTION
## Overview

There was already code related to weather alerts in the frontend and the rainfall script, but it was hard-coded to inactive. This makes it call the NWS current alerts API, using the location of the Sitka airport.

Per https://www.weather.gov/media/documentation/docs/NWS_Geolocation.pdf, using a point request to `alerts/active` (rather than a county or a zone) seems like the way to get all alerts that apply to that location, regardless of what level (zone or county) they're defined for.  API docs, where you can try out a request, are [here](https://www.weather.gov/documentation/services-web-api#/default/alerts_active).

Resolves #16

### Demo

![image](https://user-images.githubusercontent.com/6598836/165958910-a662a7e0-ffe6-4e4b-aa42-b44cae34a62a.png)

### Notes

- As noted in a comment, if this request fails it will just return "active: false". It will still log an error, but it won't prevent the script from succeeding if this is the observation and forecast endpoints work.
- As far as I can tell, the `alerts` API response doesn't include a link to any kind of human-readable description of the alert(s). There are links to detail views from the API, but that's not something we would want to link people to.  Also, there can be multiple alerts at once (in fact that's probably pretty common--e.g. "severe weather" and "flash flooding" for the same event).  So the `permalink` is always just the forecast page for the Sitka airport.  Whatever alerts are active will show up at the top of that page, so it seems like a perfectly fine solution to me.
- The response does include an `event` field that provides a short description of the alert, e.g. "High Wind Warning".  So we could potentially pull that out and show it in the bar.  Though again, since there will often be overlapping alerts, we would need to do it as a list.
- This part of a PR daisy-chain, so the branch also includes everything in PR #33.

## Testing Instructions

- Confirm that the script can set the weather advisory status and the bar will show up on the dashboard. There are two ways to the script to set "active: true" so that the weather advisory bar shows up:
  - hard-code it to true
  - change the lat/lon to a place that currently has an active weather alert (the other APIs will still be looking at Sitka, since the three APIs have three different ways of identifying the place...)
- Confirm that if the API fails (e.g. if you put a stray character in the URL so it's no longer valid)...
  - it prints an error in the console
  - but the script still finishes and produces an updated `rainfall.json`
  - the weather advisory banner doesn't show up

## Checklist

- [x] `./scripts/lint` runs without errors

