### PR TITLE
Add axios-retry to retry failed API requests

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -1,4 +1,5 @@
 const axios = require("axios");
+const axiosRetry = require("axios-retry");
 const { DateTime } = require("luxon");
 const fs = require("fs");
 
@@ -10,8 +11,26 @@ const MESOWEST_API = "https://api.synopticdata.com/v2";
 const MESOWEST_TOKEN = process.env.MESOWEST_TOKEN || "78b6412c25ea43beb10aa5399dd6fdfa";
 
 const NWS_API = "https://api.weather.gov/gridpoints/AJK/188,113";
+const STATION_LAT = 57.053;
+const STATION_LON = -135.36;
+const NWS_ALERT_API = `https://api.weather.gov/alerts/active?status=actual&message_type=alert&point=${STATION_LAT},${STATION_LON}`;
 // NWS doesn't require authentication, but they ask for an identifiable user-agent
 const NWS_USERAGENT = "(Sitka Landslide Risk Forecasting, systems@azavea.com)";
+// The link to provide when there's an active alert (it's just the current forecast page)
+const NWS_ALERT_PERMALINK = `https://forecast.weather.gov/MapClick.php?lat=${STATION_LAT}&lon=${STATION_LON}`;
+
+// Configure retries for requests. 3 retries (4 tries). The default exponential delay intervals
+// are 100ms, 200ms, and 400ms, plus a random amount of padding from 0-20%.
+axiosRetry(axios, {
+  retries: 3,
+  retryDelay: axiosRetry.exponentialDelay,
+  // Condition for whether or not the error is one that should be retried. Modified to add logging.
+  retryCondition: (err) => {
+    const shouldRetry = axiosRetry.isSafeRequestError(err);
+    console.log(`Request error for ${err.config.url}.` + (shouldRetry ? " Retrying." : ""));
+    return shouldRetry;
+  },
+});
 
 // Converts any ISO timestamp (whether it's in UTC or local time) to a luxon DateTime
 // instance in Sitka local time
@@ -210,19 +229,14 @@ async function getForecastRainfall(observed) {
 // Note: We don't want an error here to block an update, so if the API call fails it just
 //       returns a valid object with {active: false}.
 async function getWeatherAdvisory() {
-  const lat = 57.053;
-  const lon = -135.36;
   const defaultResult = {
     active: false,
-    permalink: `https://forecast.weather.gov/MapClick.php?lat=${lat}&lon=${lon}`,
+    permalink: NWS_ALERT_PERMALINK,
   };
   return axios
-    .get(
-      `https://api.weather.gov/alerts/active?status=actual&message_type=alert&point=${lat},${lon}`,
-      {
-        headers: { "User-Agent": NWS_USERAGENT },
-      }
-    )
+    .get(NWS_ALERT_API, {
+      headers: { "User-Agent": NWS_USERAGENT },
+    })
     .then((nwsResponse) => {
       return {
         ...defaultResult,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@nivo/core": "^0.79.0",
     "@nivo/scatterplot": "^0.79.1",
     "axios": "^0.26.1",
+    "axios-retry": "^3.2.5",
     "d3": "^7.3.0",
     "luxon": "^2.3.1",
     "mapbox-gl": "^2.6.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -17,6 +17,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.4":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@eslint/eslintrc@^1.0.5":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.1.tgz#8b5e1c49f4077235516bc9ec7d41378c0f69b8c6"
@@ -598,6 +605,14 @@ axe-core@^4.3.5:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
+
+axios-retry@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.2.5.tgz#64952992837c7d9a12eec156a2694a7945f60895"
+  integrity sha512-a8umkKbfIkTiYJQLx3v3TzKM85TGKB8ZQYz4zwykt2fpO64TsRlUhjaPaAb3fqMWCXFm2YhWcd8V5FHDKO9bSA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    is-retry-allowed "^2.2.0"
 
 axios@^0.26.1:
   version "0.26.1"
@@ -1957,6 +1972,11 @@ is-regex@^1.1.4:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-shared-array-buffer@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Overview

Adds the [axios-retry](https://github.com/softonic/axios-retry) package and uses it in getRainfall.js to retry API requests that fail in a way that could be transient, i.e. when there's a 500-series error.  If all the retries fail, the last error comes through and gets logged and either caught (for alerts) or not (for observations and forecasts) as usual.

Resolves #31

### Demo

This demo required two local code changes to make it fail: adding an invalid query param and forcing the `retryCondition` function to return `true`, since normally it wouldn't retry a 400 error (which makes sense--there's no reason to think a bad request will get better if you try the exact same thing again).

~/proj/sitka/sitka-landslide/frontend (feature/kjh/retry-requests)$ yarn run get-data
yarn run v1.22.18
$ node data/getRainfall.js
Request error for https://api.weather.gov/gridpoints/AJK/188,113?potato=potahto. Retrying.
Request error for https://api.weather.gov/gridpoints/AJK/188,113?potato=potahto. Retrying.
Request error for https://api.weather.gov/gridpoints/AJK/188,113?potato=potahto. Retrying.
==== ERROR ====
Error: HTTP 400 response from https://api.weather.gov/gridpoints/AJK/188,113?potato=potahto
{
  correlationId: '535cf66',
  parameterErrors: [
    {
      parameter: 'query.potato',
      message: 'Query parameter "potato" is not recognized'
    }
  ],
  title: 'Bad Request',
  type: 'https://api.weather.gov/problems/BadRequest',
  status: 400,
  detail: 'Bad Request',
  instance: 'https://api.weather.gov/requests/535cf66'
}
node:internal/process/promises:265
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "Failed to load observed or forecast rainfall data.".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

### Notes

[`axios-retry`](https://www.npmjs.com/package/axios-retry) was the first one that came up in a search, and has ~1.4M weekly downloads.  [`retry-axios`](https://www.npmjs.com/package/retry-axios) looks to be popular (~0.5M weekly downloads) and well-maintained as well.  I went with the former mainly because the initialization seemed slightly more intuitive to someone unfamiliar with Axios interceptors (such as myself).  One disadvantage of `axios-retry` is that it comes with two dependencies, whereas `retry-axios` has none (besides an `axios` peer dependency).  But I don't think that really matters under the circumstances.

## Testing Instructions

- Run `./scripts/update` to install the new packages
- Change to `frontend/` and run `yarn run get-data`. It should work just the same as before, unless you happen to hit one of the NWS API hiccups.  In that lucky event, it should log messages about the failures and say it's retrying.  If it succeeds, the rest should look as before.  If all 4 attempts fail, it should print the usual error message and exit unsuccessfully.
- Change the `const shouldRetry =` line to make the variable always true. Tweak the MESOWEST_API URL to make it wrong in some way, then run `get-data` again.  It should log the "Request error ... Retrying." message three times, then the error details.
- Fix the `MESOWEST_API` value and break `NWS_API` then `NWS_ALERT_API` in turn. They should do the same retries-then-final-error routine, except that when `NWS_ALERT_API` is broken the script should still exit successfully and write a new `rainfall.js` file.

## Checklist

- [x] `./scripts/lint` runs without errors

