### PR TITLE
Add Dockerfile for proof-of-concept AWS static deployment

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:16-bullseye-slim
+
+RUN apt-get update && \
+    apt-get install -y awscli && \
+    apt-get clean
+
+WORKDIR /app
+
+# Install packages
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile && yarn cache clean
+
+# Copy code. Annoyingly, you can't copy specific directories all at once. Directory args are
+# always treated as "copy the contents of this directory".
+COPY components components/
+COPY content content/
+COPY data data/
+COPY pages pages/
+COPY public public/
+COPY styles styles/
+COPY next.config.js ./
+
+CMD yarn export && \
+    echo "Uploading to S3..." && \
+    aws s3 sync --only-show-errors --delete out/ s3://khoekema-sitka-test/ && \
+    echo "Finished"

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -14,5 +14,6 @@ module.exports = withMDX(
   withBundleAnalyzer({
     pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
     experimental: { optimizeCss: true },
+    trailingSlash: true,
   })
 );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
     "dev": "yarn get-data && next dev -p 3008",
     "analyze": "cross-env ANALYZE=true next build",
     "build": "yarn get-data && next build",
+    "export": "yarn build && next export",
     "start": "next start",
     "lint": "next lint",
     "check-format": "prettier --check '{pages,components}/*.{js,jsx,json,css}'",


### PR DESCRIPTION
## Overview

This adds a Dockerfile and makes a couple config changes to support deploying on AWS--running a static build in ECS that writes files to S3 to be served by CloudFront.

The actual code changes here are kind of the tip of the iceberg, since most of the work I've done so far has been manually configuring and debugging AWS resources to prove this strategy will work and figure out what all the necessary pieces are.  See details below.

Connects to #38

### Demo

Note the URL, https://d3k6rtzdg4mp7d.cloudfront.net/
![image](https://user-images.githubusercontent.com/6598836/167948693-5738c538-2d1b-4915-85e6-0edcbb6d1d78.png)


### Writeup

This is a lightly-edited version of the notes I took while setting things up, so it's a mix of general ("this setting should have this value"), specific (names of the actual resources I created), and some commentary.

#### AWS Resources/Setup
- S3 bucket
  - Name: khoekema-sitka-test
  - Static website hosting: enabled
    - Index document: index.html
  - Permissions
    - Turn off the "block public access" settings
    - Set ACL to let Everyone read and list
    - Bucket policy (just the ACL doesn't do it, seemingly):
      ```
      {
          "Version": "2012-10-17",
          "Statement": [
              {
                  "Sid": "Statement1",
                  "Effect": "Allow",
                  "Principal": "*",
                  "Action": "s3:GetObject",
                  "Resource": "arn:aws:s3:::khoekema-sitka-test/*"
              },
              {
                  "Sid": "Statement2",
                  "Effect": "Allow",
                  "Principal": "*",
                  "Action": "s3:ListBucket",
                  "Resource": "arn:aws:s3:::khoekema-sitka-test"
              }
          ]
      }
      ```
- CloudFront:
  - Price class: "Use only North America and Europe"
  - Origin:
    - Origin domain: khoekema-sitka-test.s3-website-us-west-2.amazonaws.com
    - (no other changes needed, I think)
  - Behavior:
    - Viewer protocol policy: Redirect HTTP to HTTPS
    -  Caching: It doesn't seem like it's possible to have changes on S3 invalidate the CloudFront cache.
      If it were, we could avoid reloading the raster tiles.  It might also be possible to have different behaviors based on path. But it's not worth over-thinking it. Just setting a short cache timeout for everything is fine.
  
        I used these somewhat abritrarily-chosen options. We might just want to set it to 30 seconds across the board, i.e. limit compulsive reloading but otherwise essentially don't cache.
        - Legacy cache settings
          - Object caching: customize
            - Minimum TTL: 30
            - Maximum TTL: 600
            - Default TTL: 60
- ECS container repository
  - Name: khoekema-sitka-test
    The endpoint is just derived from account ID, region, and name: 279682201306.dkr.ecr.us-west-2.amazonaws.com/khoekema-sitka-test
- ECS cluster
  - Networking only
    (that's all there is to it, really. there aren't many options, and we don't need a custom VPC)
- IAM role (needed to give the ECS task access to S3)
  - Name: ecsTaskExecutionWithS3AccessRole
  - Policies:
    - AmazonECSTaskExecutionRolePolicy
    - AmazonS3FullAccess
- ECS task definition (can't be created until you've built and pushed the container to the container repository)
  - Task role: ecsTaskExecutionWithS3AccessRole
  - Task execution role: same, I guess? Possibly we could use an S3-only one above and the standard execution role here, but I'm not sure, since it doesn't offer any roles without the task execution permissions in either droplist. Simpler to just use the same one, which definitely works.
  - Memory and CPU: 1 vCPU/2GB. See note below.
- EventBridge rule
  - Event schedule: cron format.
  - Target: You have to configure the same parameters that the ECS "Run task" menu requires
    - Target type: ECS task
    - Launch Type: Fargate
    - Platform version: LATEST
    - Subnets: subnet-b64a919d (I just picked the first one offered in the ECS "Run new Task" menu. I don't think it matters, since we're not trying to talk to anything but S3.)
    - Security groups: sg-9bf261e0 (that's the default security group for the cluster's VPC)
    - Make sure "Auto-assign Public IP" is set to ENABLED, since it'll need that to make requests to the APIs

#### Build/Deploy

Either of the methods below will update the resources in S3, which (per the short caching rule) should mean reloading [the CloudFront site](https://d3k6rtzdg4mp7d.cloudfront.net/) will cause the "Last updated..." message to update (unless you _just_ loaded the old version, in which case wait a minute or two and try again).

##### Local
Once the S3 and CloudFront resources are set up, you can deploy the site by running the container locally (from `frontend/`):
```
docker build -t sitka-build .
docker run --rm -v ~/.aws/:/root/.aws:ro -e AWS_PROFILE=research sitka-build
```
The Dockerfile is currently hard-coded to write to the S3 bucket I made.  You'll need to use a configured AWS profile for the Azavea R&D account (change the name if yours isn't called "research") to write to that bucket.

You can also override the `CMD` from the container to copy the files to a local directory rather than up to S3.  Build the container and make a directory called `output`, then run:
```
docker run --rm -v $(pwd)/output:/output sitka-build bash -c "yarn export && cp -r out/* /output"
```
That should give you a fully-built version of the site in `output/`, which you can view by running `python3 -m http.server` or `http-server` from the directory.

##### ECS
When the container repository has been created, these commands (run from `frontend/`, just like the local ones) will publish the container to it:
```
aws --profile research ecr get-login-password --region us-west-2 \
  | docker login --username AWS --password-stdin 279682201306.dkr.ecr.us-west-2.amazonaws.com
docker build -t khoekema-sitka-test .
docker tag khoekema-sitka-test:latest 279682201306.dkr.ecr.us-west-2.amazonaws.com/khoekema-sitka-test:latest
docker push 279682201306.dkr.ecr.us-west-2.amazonaws.com/khoekema-sitka-test:latest
```
Once you've done that, and created a task definition for the container on ECS, you can go to [the "Tasks" tab on the AWS console page for the ECS cluster](https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/clusters/khoekema-sitka-test/tasks) and click the "Run new Task" button.  It makes you set a bunch of parameters--see the "EventBridge rule" section above.  Once you've clicked "Run Task", you should be able to watch the task initialize (it takes a minute or so for it to download the container and actually start running) and follow the link in the task details page to see the log output in CloudWatch.

### Notes

#### CPU and Memory
The build uses more than 1GB of RAM on my system, but it doesn't use that much on Fargate. I set up a cluster with "Container Insights" monitoring and ran a few jobs on it, and learned that:
- The process is CPU-bound. It will use more CPU if you give it more, and most of the time spent during the build is in the "Creating an optimized production build..." step, which definitely scales with CPU, e.g. it takes about 45 seconds with 1 vCPU, 30 seconds with 2.
- The memory usage scales with CPU usage. I think that's because the build runs multiple threads. On my machine, it spikes above 1GB when building, but at one point it also says "Launching 7 workers". On ECS with only one CPU, it only went as high as 516MB on one run, even less on others (per the monitoring).
- There's a minimum amount of memory you can provision for Fargate tasks--2GB per vCPU, I believe--so effectively we don't have to worry about memory. We can choose a CPU allocation based on how fast we want it to run, and the corresponding minimum memory allocation will be sufficient.

#### ECS vs Lambda

The build could be done with Lambda rather than ECS Fargate, with the other pieces staying pretty much the same.  I initially picked ECS because using a container-based process is more familiar, as compared to working in a Lambda runtime, and makes it easier to translate between development/local and production/deployed environments.

I did a search to see if there were any clear reasons to prefer one or another that people had written about, and found [this post](https://noise.getoto.net/2021/07/12/should-i-run-my-containers-on-aws-fargate-aws-lambda-or-both/) that has some time and cost comparisons.  It says Fargate is slower to start up but substantially cheaper when comparing similar CPU/RAM allocations.  Startup time doesn't matter to us--the only bit of timing that matters (and that only barely--it's fine as long as it's not longer than a minute or two) is the amount of time between when the weather data is retrieved and when the page based on it goes live.  For that, CPU is the important factor, which adds to Fargate's advantage, since you can provision CPU and RAM quasi-independently, whereas on Lambda you pick a memory allocation and the CPU is scaled accordingly using a fixed ratio (so we could end up over-provisioning memory by a lot to get the CPU performance we want).

### Next steps

It seems clear to me that this would work.  It's amazing how many moving pieces are involved in doing anything in AWS, but this is essentially pretty simple.  And one nice attribute of this strategy is that it uses the various tools/services in ways that are pretty well in line with their standard functions.  I.e. we're not doing anything that technically works but kind of goes against the grain of how the maintainers of the tool imagine it being used.  The closest thing to that is the CloudFront/S3 connection.  It turns out we can't use the normal "serve this S3 bucket from CloudFront" setup, because it will handle using `index.html` for the root, but it doesn't like other URLs that are just the directory rather than the actual file.  But doing the "S3 website" thing works and is supported, just a little off the beaten track.

So if we want to use this strategy, the next steps would be:
- Figure out what AWS account to deploy in (presumably the Science Center signs up for one)
- Implement it in Terraform*, with variables so we can easily do staging and production deployments
- Add scripts to drive the deployment process

* There are other tools that could do it, but Terraform is the one we've used before, so it seems like a clear winner in terms of doing things that are familiar and having useful reference projects rather than trying to learn a whole new system.

## Testing Instructions

It wouldn't make sense at this stage to go through the whole manual process and make a second copy of everything just to validate things, but a general "seems OK" level of review could include:
- Do the "local" build/execute process to make sure it works on your system.
- Look in the R&D AWS account at the various resources with names that start "khoekema-sitka-test"
- Note that https://d3k6rtzdg4mp7d.cloudfront.net/ gets updated occasionally (twice a day as of this writing)

## Checklist

- [x] `./scripts/lint` runs without errors

