### PR TITLE
Deployment tweaks and additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,30 @@ Note that it is recommended to configure your editor to auto-format your code vi
 
 ## Deployment
 
-We have no terraform tfvars to download so it's just:
+To run the deployment commands, you'll need an AWS access key pair for the Sitka AWS account.  It should be configured as a profile named `sitka`.
 
+### Infrastructure
+You'll need the [Terraform CLI](https://learn.hashicorp.com/tutorials/terraform/install-cli) installed, with a version that satisfies the required version in `versions.tf`.
+Since we currently have no tfvars file, there's nothing to download.
+
+From the `deployment/terraform` directory, first initialize and plan:
 ```
-$ cd deployment/terraform
-$ terraform plan
-check output for sanity
-$ terraform apply
-check output for sanity
+export AWS_PROFILE=sitka
+terraform init -backend-config="bucket=sitka-production-config-us-west-2"
+terraform plan
 ```
+Check the output to make sure it's going to do what you think it should, and no more. Then apply:
+```
+terraform apply
+```
+Check the output of that command to make sure it did what you expected.
+
+### Code
+The application code is published as a Docker container, which gets run periodically by a scheduled ECS task to update the static site.
+
+To build and publish the code, make sure your local checkout is in the state you want to publish (on the right branch, up to date, and with no local modifications to tracked files) then run:
+```
+./scripts/cipublish
+```
+
+The newly published code will be used the next time the automatic site rebuild is triggered. To update the static site immediately, you can trigger a build by going to [the ECS console](https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/clusters/sitkaproduction/tasks) and clicking "Run new Task".  You can use the parameters in the "Targets" tab of the scheduling rule on [EventBridge](https://us-west-2.console.aws.amazon.com/events/home?region=us-west-2#/rules) as a reference for setting the runtime parameters.

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,5 +1,6 @@
 terraform {
   backend "s3" {
+    key = "terraform"
     region  = "us-west-2"
     encrypt = "false"
   }

--- a/deployment/terraform/site.tf
+++ b/deployment/terraform/site.tf
@@ -67,8 +67,21 @@ resource "aws_s3_bucket_acl" "site_acl" {
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket.site.bucket_regional_domain_name
+    domain_name = aws_s3_bucket.site.website_endpoint
     origin_id   = aws_s3_bucket.site.id
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_keepalive_timeout = 5
+      origin_protocol_policy   = "http-only"
+      origin_read_timeout      = 30
+      origin_ssl_protocols     = [
+        "TLSv1",
+        "TLSv1.1",
+        "TLSv1.2",
+      ]
+    }
   }
 
   enabled             = true

--- a/deployment/terraform/site.tf
+++ b/deployment/terraform/site.tf
@@ -252,16 +252,16 @@ resource "aws_cloudwatch_log_group" "app" {
   retention_in_days = 30
 }
 
-resource "aws_cloudwatch_event_rule" "run_every" {
-  name                = "run_every"
-  description         = "Run every 20"
-  schedule_expression = "rate(20 minutes)"
+resource "aws_cloudwatch_event_rule" "publish_site" {
+  name                = "publish_site"
+  description         = "Periodically build and publish the site"
+  schedule_expression = "cron(17,37,57 * * * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
   target_id = "build"
   arn       = aws_ecs_cluster.default.arn
-  rule      = aws_cloudwatch_event_rule.run_every.name
+  rule      = aws_cloudwatch_event_rule.publish_site.name
   role_arn  = aws_iam_role.ecs_task_role.arn
 
   ecs_target {

--- a/deployment/terraform/site.tf
+++ b/deployment/terraform/site.tf
@@ -176,7 +176,11 @@ resource "aws_iam_role" "ecs_task_role" {
       }
     ]
   })
-  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy", aws_iam_policy.eventbridge_invoke_ecs.arn]
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+    aws_iam_policy.eventbridge_invoke_ecs.arn
+  ]
 }
 
 data "aws_iam_policy_document" "eventbridge_invoke_ecs" {

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -42,6 +42,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         # Login to Amazon ECR with the local Docker client.
         amazon_ecr_login
 
+        docker tag "${ENVIRONMENT}:latest" "${ECR_REGISTRY}/${ENVIRONMENT}:latest"
         docker push "${ECR_REGISTRY}/$ENVIRONMENT:latest"
     fi
 fi


### PR DESCRIPTION
## Overview

I ran into a few small things while using the branch from PR #42 yesterday evening, then made some more local changes while working through a permissions error on the deployed site, so I figured I'd keep going in that vein and make a sub-PR. So here it is.

What's here:
- A line in `cipublish` to tag the package with the ECR repository identifier. The `docker push` command yelled at me when I tried to do it without that.
- Some small formatting changes in `site.tf` (removing quotes that Terraform said are deprecated, breaking the `managed_policy_arns` list onto multiple lines)
- Switching CloudFront to a "custom" origin rather than a standard S3 origin.  After deploying the site yesterday evening, I was poking around and got this when I reloaded a page:
  ![image](https://user-images.githubusercontent.com/6598836/170547154-377778ec-021c-4e02-9e3f-0f6b57868891.png)
  I recognized that from when I was working on PR #39--it happens because (I think) CloudFront will fall back to `index.html` for the root, but not for any other paths. For something like `areas-at-risk/` it will look for a key by that name and fail when none is found.  The S3 website endpoint, on the other hand, knows to look for an `index.html` in sub-paths as well.
  Regardless of the particulars of why, using a custom origin pointed at the website endpoint of an S3 bucket works where using a standard S3 endpoint doesn't.  So this switches the CloudFront origin to that.
  Note that the terraform plan won't show this, because I made the change manually to resolve the errors.
- Changing the schedule for the EventBridge rule to a fixed schedule, rather than an interval.  As noted in more detail in the commit message, this will tend to increase the average freshness of the information on the site, and also make it easier to know at a glance if an update has failed.
- More words in the "Deployment" section of the README.  I added a bit more context to the Terraform instructions, and added a section about publishing the container and how that relates to publishing the site itself.  I also added a `key` field to `config.tf` so that only the bucket would need to be provided to `terraform init` at runtime.

### Demo

![image](https://user-images.githubusercontent.com/6598836/170549787-5ce8f72d-785e-4260-9ab4-281c3e70fc93.png)

![image](https://user-images.githubusercontent.com/6598836/170549802-d9c8e257-a15b-44fa-98d6-b46a15bb251d.png)

### Notes

- I've gone back and forth a bit about having the container on ECR just always be 'latest'. In some other ECS projects we tag the containers with the git hash then update the tasks to point to the new containers. Something about having the previous version right there feels comforting, but I don't think it's actually likely to be useful. So letting versioning happen locally and just having each version of the container replace the previous one on ECR is probably fine.

## Testing Instructions

- Review the changes to README.md and make sure they're correct and make sense.
- Reinitialize Terraform and run `plan`. The results should look the same as above.
- Apply the plan?  I haven't done this part myself, since the only environment we have at the moment is production.

## Checklist

- [x] `./scripts/lint` runs without errors

