### PR TITLE
Add www redirect

### DIFF
--- a/deployment/terraform/site.tf
+++ b/deployment/terraform/site.tf
@@ -61,6 +61,20 @@ resource "aws_s3_bucket_acl" "site_acl" {
   acl    = "public-read"
 }
 
+# Redirect from www
+resource "aws_s3_bucket" "www-redirect" {
+  bucket = "www.${var.domain_name}"
+}
+
+resource "aws_s3_bucket_website_configuration" "www-redirect" {
+  bucket = aws_s3_bucket.www-redirect.bucket
+
+  redirect_all_requests_to {
+    host_name = var.domain_name
+    protocol = "https"
+  }
+}
+
 #
 # Cloudfront
 #
@@ -314,12 +328,23 @@ resource "aws_route53_record" "site_ipv6" {
   }
 }
 
+resource "aws_route53_record" "www-redirect" {
+  zone_id = aws_route53_zone.external.id
+  name    = "www.${var.domain_name}"
+  type    = "A"
 
-#Certifcate
+  alias {
+    name                   = aws_s3_bucket_website_configuration.www-redirect.website_domain
+    zone_id                = aws_s3_bucket.www-redirect.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
 
+# Certificate
 resource "aws_acm_certificate" "site" {
   provider          = aws.us-east-1
   domain_name       = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
   validation_method = "DNS"
 
   lifecycle {


### PR DESCRIPTION
Required new s3 bucket and route53 alias to it
Initially looked at just having site support both, but that's not as
great from an SEO perspective - did increase the cert to potentially cover
*.domainname.org in case needed in future.

### Demo

$ wget www.sitkalandslide.org/
--2022-06-13 15:09:16--  http://www.sitkalandslide.org/
Resolving www.sitkalandslide.org (www.sitkalandslide.org)... 52.218.201.11
Connecting to www.sitkalandslide.org (www.sitkalandslide.org)|52.218.201.11|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://sitkalandslide.org/ [following]
--2022-06-13 15:09:16--  https://sitkalandslide.org/
Resolving sitkalandslide.org (sitkalandslide.org)... 54.192.81.4, 54.192.81.127, 54.192.81.36, ...
Connecting to sitkalandslide.org (sitkalandslide.org)|54.192.81.4|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 60107 (59K) [text/html]
Saving to: ‘index.html’

## Testing Instructions

 * Confirm www.sitkalandslide.org resolves for you  - note I did not wire up HTTPS support for the subdomain.

## Checklist

- [X] `./scripts/lint` runs without errors

