### PR TITLE
Add CNAME option to staging site config so it stays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./frontend/out
+          cname: staging.sitkalandslide.org


### PR DESCRIPTION
Missed option that was automatically added by GH user interface.