### PR TITLE
Switch to MesoWest timeseries API

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -145,37 +145,49 @@ function normalizedRiskNum(rainfall) {
 
 // Download observed 3hr rainfall total at the Sitka airport weather station over the past 6 hours
 async function getPastRainfall() {
-  const mesoResponse = await axios
-    .get(`${MESOWEST_API}/stations/precip`, {
-      params: {
-        token: MESOWEST_TOKEN,
-        stid: "PASI", // Sitka airport station ID
-        pmode: "last",
-        accum_hours: "3,6",
-        obtimezone: "local",
-      },
-    })
-    .catch(logRequestError);
+  const COMMON_MESOWEST_PARAMS = {
+    token: MESOWEST_TOKEN,
+    stid: "PASI", // Sitka airport station ID
+    obtimezone: "local",
+    precip: 1, // https://developers.synopticdata.com/mesonet/v2/stations/timeseries/
+  };
+  const [threeHourResponse, sixHourResponse] = await Promise.all([
+    axios
+      .get(`${MESOWEST_API}/stations/timeseries`, {
+        params: { ...COMMON_MESOWEST_PARAMS, recent: 60 * 3 },
+      })
+      .catch(logRequestError),
+    axios
+      .get(`${MESOWEST_API}/stations/timeseries`, {
+        params: { ...COMMON_MESOWEST_PARAMS, recent: 60 * 6 },
+      })
+      .catch(logRequestError),
+  ]);
 
-  if (!mesoResponse) {
+  if (!threeHourResponse || !sixHourResponse) {
     return null;
   }
 
   // Pull the observations out from the depths of the response
-  const data = mesoResponse.data.STATION[0].OBSERVATIONS.precipitation;
-  const threeHourObs = data.find((d) => d.accum_hours === 3);
-  const sixHourObs = data.find((d) => d.accum_hours === 6);
-  const precip = threeHourObs.total * EXAGGERATION_FACTOR;
+  const threeHourObs = threeHourResponse.data.STATION[0].OBSERVATIONS.precip_accumulated_set_1d;
+  const sixHourObs = sixHourResponse.data.STATION[0].OBSERVATIONS.precip_accumulated_set_1d;
+
+  // Each `precip_accumulated_set_1d` field is an array where the individual entries are running
+  // totals of precipitation over the lookback period up to that point, so to get the total for the
+  // entire period, we need to take the last element.
+  const threeHourTotal = threeHourObs[threeHourObs.length - 1] * EXAGGERATION_FACTOR;
+  const sixHourTotal = sixHourObs[sixHourObs.length - 1] * EXAGGERATION_FACTOR;
+  const precip = threeHourTotal;
   // Calculate risk based on the highest 3-hour precip within the past 6 hours
-  const riskPrecip =
-    Math.max(threeHourObs.total, sixHourObs.total - threeHourObs.total) * EXAGGERATION_FACTOR;
+  const riskPrecip = Math.max(threeHourTotal, sixHourTotal - threeHourTotal);
+  const threeHourTimestamps = threeHourResponse.data.STATION[0].OBSERVATIONS.date_time;
 
   return {
-    timestamp: toLocalTimestamp(threeHourObs.last_report),
+    timestamp: toLocalTimestamp(threeHourTimestamps[threeHourTimestamps.length - 1]),
     dateTimeDetails: { label: "Current risk" },
-    precip: precip,
+    precip: round(precip, 4),
     precipInches: mmToInches(precip),
-    riskPrecip: riskPrecip,
+    riskPrecip: round(riskPrecip, 4),
     riskPrecipInches: mmToInches(riskPrecip),
     riskProb: round(normalizedRiskNum(riskPrecip), 4),
     riskLevel: landslideRisk(riskPrecip),


### PR DESCRIPTION
## Overview

From MesoWest, the `/timeseries` API is available on the free plan, while the endpoint we were previously using (`/precip`) shifted to being only available with a paid plan.

This PR is based on the instructions provided here:
https://support.synopticdata.com/portal/en/kb/articles/using-basic-derived-precipitation-in-place-of-the-advanced-precipitation-service-16-6-2022

as well as the conversation with Synoptic in #53 .

### Notes

The idea is for this to result in the same data that the site currently uses, but I discovered some differences between the two endpoints:
- The `precip` endpoint appears to apply some kind of rounding to its numbers, while the `timeseries` endpoint does not. On `develop`, I'm currently seeing `"precip": 0.055` in `rainfall.json`, but on this branch the value is `"precip": 0.055399999999972714,`. As far as I can tell we never display this value without rounding it ourselves, so I don't think the lack of rounding from the API matters, but if that's not right then we might need to round this value.
- The timestamp fields seem to function differently on the `timeseries` endpoint than the `precip` endpoint. With `precip`, it looks like the `last_report` field tells us the last time that an observation was made specifically for precipitation. With `timeseries`, all we have is a field called `date_time` which gives us the datetime associated with each timeseries point, and I think we get a new point each time _any_ of the station's sensors reports a new value. What this means in practice is that the last reported update time from `timeseries`'s `datetime` is usually more recent than the `last_report` field from `precip`. I don't think this should be a problem since it still tells us that the site is receiving fresh data, which is my understanding of how that field is used, but I wanted to flag it. I'm not sure whether there's a way to resolve this if we wanted to -- I don't immediately see an easy way to get a timestamp for the latest observation _from a specific sensor_ from `/timeseries`, but there may be other ways to use the free API that can provide this information.
- There were some null values in the `precip_accumulated_set_1d` timeseries array. We only care about the last entry in the array, and if I'm understanding how the endpoint works correctly, I think the last entry in the array would only be null if the station reported nulls for an entire 3- or 6-hour stretch leading up to when we query the API. That seems unlikely to happen (and would constitute an update failure, I think) so I haven't added null handling to the updated code. Please let me know if that's not the right assumption!

## Testing Instructions

 * Get set up to develop on the data fetcher script. I did this by going into the `frontend` directory and running `nvm use && yvm use` but there might be a better way that I don't know about.
 * Run `yarn get-data && cp data/rainfall.json data/rainfall-ts.json && git checkout develop && yarn get-data` . This will result in `frontend/data/rainfall-ts.json` being populated by this branch, and `frontend/data/rainfall.json` being populated by `develop`, as close as possible in time.
 * Run `diff data/rainfall.json data/rainfall-ts.json` and confirm that the files are the same, subject to the caveats above.
 * Launch `/scripts/server` and verify that the site still looks and functions the same.

## Checklist

- [x] `./scripts/lint` runs without errors