### PR TITLE
add TerrainWorks to partners list

### DIFF
--- a/frontend/pages/about.mdx
+++ b/frontend/pages/about.mdx
@@ -33,5 +33,6 @@ This dashboard was created by the Landslide Research Team collaborators includin
 - Sitka School District
 - Mt. Edgecumbe High School
 - Greater Sitka Chamber of Commerce
+- TerrainWorks
 
 export default ({ children }) => <Page title={page.title}>{children}</Page>;


### PR DESCRIPTION
## Overview

Add TerrainWorks to partners list on About Us page.

Resolves #60

### Demo

![demo-sitka-partners-list](https://user-images.githubusercontent.com/16727618/182213457-54762b84-95b1-4a52-914a-9e50382103f3.png)


## Testing Instructions

 * Simply adds list item on About Us page, visual inspection and running `./scripts/lint` is sufficient.

## Checklist

- [X] `./scripts/lint` runs without errors

