### PR TITLE
Only use previous rainfall when risk is higher, and always show current amount

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -171,26 +171,28 @@ async function getPastRainfall() {
   // Pull the observations out from the depths of the response
   const threeHourObs = threeHourResponse.data.STATION[0].OBSERVATIONS.precip_accumulated_set_1d;
   const sixHourObs = sixHourResponse.data.STATION[0].OBSERVATIONS.precip_accumulated_set_1d;
+  const threeHourTimestamps = threeHourResponse.data.STATION[0].OBSERVATIONS.date_time;
 
   // Each `precip_accumulated_set_1d` field is an array where the individual entries are running
   // totals of precipitation over the lookback period up to that point, so to get the total for the
   // entire period, we need to take the last element.
-  const threeHourTotal = threeHourObs[threeHourObs.length - 1] * EXAGGERATION_FACTOR;
-  const sixHourTotal = sixHourObs[sixHourObs.length - 1] * EXAGGERATION_FACTOR;
-  const precip = threeHourTotal;
-  // Calculate risk based on the highest 3-hour precip within the past 6 hours
-  const riskPrecip = Math.max(threeHourTotal, sixHourTotal - threeHourTotal);
-  const threeHourTimestamps = threeHourResponse.data.STATION[0].OBSERVATIONS.date_time;
+  const precip = round(threeHourObs[threeHourObs.length - 1] * EXAGGERATION_FACTOR, 4);
+  const prevPrecip = round(sixHourObs[sixHourObs.length - 1] * EXAGGERATION_FACTOR - precip, 4);
+
+  // If the earlier precip was higher than the recent total, by enough to cause the risk level to
+  // be higher than it would for the recent amount, calculate risk based on that higher total.
+  const riskIsElevatedFromPreviousPrecip = landslideRisk(prevPrecip) > landslideRisk(precip);
+  const riskPrecip = riskIsElevatedFromPreviousPrecip ? prevPrecip : precip;
 
   return {
     timestamp: toLocalTimestamp(threeHourTimestamps[threeHourTimestamps.length - 1]),
     dateTimeDetails: { label: "Current risk" },
-    precip: round(precip, 4),
+    precip,
     precipInches: mmToInches(precip),
-    riskPrecip: round(riskPrecip, 4),
-    riskPrecipInches: mmToInches(riskPrecip),
+    prevPrecip, // Needed for the look-back window of the first forecast period
     riskProb: round(normalizedRiskNum(riskPrecip), 4),
     riskLevel: landslideRisk(riskPrecip),
+    riskIsElevatedFromPreviousPrecip,
   };
 }
 
@@ -228,16 +230,23 @@ async function getForecastRainfall(observed) {
   // question or the two previous 3-hour chunks.
   const prevPrecip = observed.concat(futureForecasts.map((f) => f.precip));
   const riskForecasts = futureForecasts.map((forecast, i) => {
-    const riskPrecip = Math.max(forecast.precip, prevPrecip[i], prevPrecip[i + 1]);
+    // If the forecast total for one of the previous periods is higher than the total for the
+    // period in question by enough to cause increased risk, calculate the risk based on the
+    // higher total.
+    const maxPrecip = Math.max(forecast.precip, prevPrecip[i], prevPrecip[i + 1]);
+    const riskIsElevatedFromPreviousPrecip =
+      landslideRisk(maxPrecip) > landslideRisk(forecast.precip);
+    const riskPrecip = riskIsElevatedFromPreviousPrecip ? maxPrecip : forecast.precip;
+
     return {
       ...forecast,
+      precipInches: mmToInches(forecast.precip),
       hour: toLocalDateTime(forecast.timestamp).toFormat("ha"),
       shortTimestamp: toShortTimestamp(forecast.timestamp),
       dateTimeDetails: toDateTimeDetails(forecast.timestamp),
-      riskPrecip,
-      riskPrecipInches: mmToInches(riskPrecip),
       riskProb: round(normalizedRiskNum(riskPrecip), 4),
       riskLevel: landslideRisk(riskPrecip),
+      riskIsElevatedFromPreviousPrecip,
     };
   });
   return riskForecasts;
@@ -314,10 +323,8 @@ async function rainfall() {
   const current = await getPastRainfall();
   if (current) {
     // Pass the observed amounts to the forecast function for use in the look-back of the first
-    // couple forecast periods. Note that 'riskPrecip' could be the earlier observation or it could
-    // be a copy of the most recent one, depending on which was higher, but since the calculations
-    // just want to know the max, it doesn't matter.
-    const forecasts = await getForecastRainfall([current.riskPrecip, current.precip]);
+    // couple forecast periods.
+    const forecasts = await getForecastRainfall([current.prevPrecip, current.precip]);
     if (forecasts) {
       const twentyFourHours = composeTwentyFourHours(forecasts);
       const threeDays = composeThreeDays(forecasts);

--- a/frontend/pages/detail/[timestamp].js
+++ b/frontend/pages/detail/[timestamp].js
@@ -75,7 +75,7 @@ export default function Detail({ activeData, previousSlug, nextSlug }) {
       data: [
         {
           x: lastHistoricalDate,
-          y: activeData.riskPrecipInches,
+          y: activeData.precipInches,
           event: 2,
         },
       ],
@@ -236,7 +236,7 @@ export default function Detail({ activeData, previousSlug, nextSlug }) {
           <hr />
           <h3 className={styles.figureHeading}>3 hour rainfall</h3>
           <div className={styles.figureText} style={{ marginBottom: "var(--space-100)" }}>
-            {activeData.riskPrecipInches} inches
+            {activeData.precipInches} inches
           </div>
           <p>
             Research in Sitka shows that rainfall measured over a 3-hour interval is the best way to
@@ -244,14 +244,14 @@ export default function Detail({ activeData, previousSlug, nextSlug }) {
           </p>
           <div className={styles.chart}>
             <div
-              className={`${styles.forecast} ${activeData.riskPrecipInches > 1 && styles.arrowUp}`}
+              className={`${styles.forecast} ${activeData.precipInches > 1 && styles.arrowUp}`}
               // Position the annotation arrow; set a fixed position for when the current value is
               // higher than all of the historical data
               style={{
                 bottom:
-                  activeData.riskPrecipInches > maxRiskPrecipInches
+                  activeData.precipInches > maxRiskPrecipInches
                     ? "90%"
-                    : (activeData.riskPrecipInches / maxRiskPrecipInches) * 100 * 0.9 + "%",
+                    : (activeData.precipInches / maxRiskPrecipInches) * 100 * 0.9 + "%",
               }}
             >
               <span className={styles.forecastText}>{activeData.dateTimeDetails.label}</span>


### PR DESCRIPTION
## Overview

Changes the detail view so that it uses the rainfall amount for the period in question, rather than the max amount from that period or the two preceding it, for the text and chart.  The risk is still based on the highest amount within the look-back window, but the rainfall amount is the actual amount for the period.

This is the first part of #63.  The other part is making it clear to the user what we're doing, by adding an explanation in situations where the risk level, based on a recent period of heavy rainfall, is higher than what the current amount would justify.  The current change will make the behavior of the site look less weird to people who are checking it against other sources of rainfall information (like the hourly forecast, or looking out their window).  It could look slightly more weird as well, since the dot on the historical chart gets colored by the risk level, and it could be different from the risk level stated at the top, but that seems like a reasonable tradeoff, and we'll be adding the explanatory text soon.

Connects #63

### Demo

This series of detail screens shows that the look-back window isn't applying to the rainfall amount--if it were, you wouldn't see the amount go up then immediately decrease again, since the lower rainfall totals for the periods where it's decreasing would have been replaced by the higher recent totals. 
![Peek 2022-09-29 17-13](https://user-images.githubusercontent.com/6598836/193143132-050f819e-93da-4f0d-a8e5-dd06038fb347.gif)

Here's an example (using EXAGGERATION_FACTOR) of the risk being high when the forecast precip is fairly low:
![image](https://user-images.githubusercontent.com/6598836/193184962-682e01b9-97b0-4179-9ffd-b87daf29e617.png)

### Notes

In the issue, I noted two possible ways of making the `getRainfall.js` script provide enough information for the front end to tell when the risk level is held high, and I ended up going back and forth a bit about which would be better.  To the point that I made a branch for the approach where the script provides two different risk levels to the front end (feature/kjh/risk-window-adjustments-bufferedRiskLevel).  But then I tried the other way--just having the script provide a boolean field saying whether or not the risk is elevated due to an earlier period--which I initially thought was probably the better choice, and writing it out reinforced that conclusion.  The code is shorter and more self-contained, and it avoids adding extra similar-but-distinct variables that muddy the waters.

## Testing Instructions

Load the site and look at [the Current risk](http://localhost:3008/detail/current/) view and the detail view for the forecast time periods.  The rainfall total should move up and down.

Run the data fetcher again with EXAGGERATION_FACTOR set, to be able to see some results with elevated risk, e.g. `EXAGGERATION_FACTOR=5 yarn run get-data` (run from `frontend/`. And adjust the number up or down, depending on the actual weather, to get it to produce a mix of risk levels).  Look through the detail views again for time periods, like the one shown above, that have elevated risk with a rainfall amount that would fall into the "low" range.

## Checklist

- [x] `./scripts/lint` runs without errors

