### PR TITLE
Fix bad subtraction and rounding in current precipitation calculation

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -96,10 +96,13 @@ function logRequestError(error) {
   }
 }
 
-// Apparently rounding is a mess in Javascript and this mess is the preferred workaround
-// See https://www.jacklmoore.com/notes/rounding-in-javascript/
+// Apparently there's no builtin Javascript function that actually rounds decimals properly.
+// But there are workarounds. https://www.jacklmoore.com/notes/rounding-in-javascript/ has one,
+// but it breaks down (badly--it returns NaN) if the number is already in scientific notation.
+// https://sanori.github.io/2019/04/JavaScript-Pitfalls-Tips-toFixed/ has a more robust one.
 function round(value, decimals) {
-  return Number(Math.round(value + "e" + decimals) + "e-" + decimals);
+  const placeMultiplier = Math.pow(10, decimals);
+  return Number((Math.floor(value * placeMultiplier + 0.5) / placeMultiplier).toFixed(decimals));
 }
 
 function mmToInches(mm) {
@@ -178,8 +181,10 @@ async function getPastRainfall() {
   // Each `precip_accumulated_set_1d` field is an array where the individual entries are running
   // totals of precipitation over the lookback period up to that point, so to get the total for the
   // entire period, we need to take the last element.
-  const precip = round(threeHourObs[threeHourObs.length - 1] * EXAGGERATION_FACTOR, 4);
-  const prevPrecip = round(sixHourObs[sixHourObs.length - 1] * EXAGGERATION_FACTOR - precip, 4);
+  const threeHourTotal = threeHourObs[threeHourObs.length - 1] * EXAGGERATION_FACTOR;
+  const sixHourTotal = sixHourObs[sixHourObs.length - 1] * EXAGGERATION_FACTOR;
+  const precip = round(threeHourTotal, 4);
+  const prevPrecip = round(sixHourTotal - threeHourTotal, 4);
 
   // If the earlier precip was higher than the recent total, by enough to cause the risk level to
   // be higher than it would for the recent amount, calculate risk based on that higher total.

--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -123,8 +123,10 @@ function landslideRisk(rainfall) {
     return 0;
   } else if (prob <= 0.7) {
     return 1;
-  } else {
+  } else if (prob > 0.7) {
     return 2;
+  } else {
+    throw `Error processing rainfall data: rainfall ${rainfall}, landslide probability ${prob}`;
   }
 }
 


### PR DESCRIPTION
## Overview

The site was showing "High" risk even though the rainfall was minimal and had been for a while.
It turns out this was a combination of an error in the revised risk and precip calculations launched on Friday and some other things that could be considered latent bugs.
Here's how it went:
- The raw 3-hour rainfall amount happened to have a long messy decimal (`0.029999999999972715`)
- There wasn't any rain in the preceding 3 hours, so the 6-hour total was the same
- The calculation for `prevPrecip` subtracted the rounded 3-hour total (`0.03`) from the unrounded 6-hour total, so it got a small (and negative, though that's not directly relevant) answer, `-2.7283730830163222e-14`
- The `round` function couldn't handle that, and returned `NaN`
- That `NaN` made it to the landslide probability calculation, which also returned `NaN`
- The `landslideRisk` function uses the probability function, but didn't account for invalid values, so it just returned a "High" value if the probability didn't fall into the low or medium range.

So there are three problems there:
- subtracting a rounded number from an unrounded one produces a messy remainder
- the rounding function can't handle scientific notation
- the risk level function defaults to "high" rather than failing on an invalid input

This changes the calculation to first subtract then round, changes the rounding function to a more robust one, and makes the risk level function throw an error if it gets a bad probability value.

### Demo

Hard to demo, since it's a "failure to fail" type situation. Also it depends on rainfall history, which is already different and wouldn't trigger the error.

## Testing Instructions

This isn't so easy because the rainfall has changed and it's not that easy to reach in and fiddle with the rainfall processing script.

Here's a bit of javascript that you can run in a node shell or the browser console to see the subtraction and rounding errors happen:
```js
function badRound(value, decimals) {
  return Number(Math.round(value + "e" + decimals) + "e-" + decimals);
}

function goodRound(value, decimals) {
  const placeMultiplier = Math.pow(10, decimals);
  return Number((Math.floor(value * placeMultiplier + 0.5) / placeMultiplier).toFixed(decimals));
}

const threeHourTotal = 0.029999999999972715;
const sixHourTotal = threeHourTotal;

const precip = goodRound(threeHourTotal, 4);
const badSubtraction = sixHourTotal - precip;

// Returns NaN
badRound(badSubtraction, 4)

// Returns 0
goodRound(badSubtraction, 4)
```

## Checklist

- [x] `./scripts/lint` runs without errors

