### PR TITLE
Remove banner and adjust build schedule

### DIFF
--- a/deployment/terraform/site.tf
+++ b/deployment/terraform/site.tf
@@ -100,6 +100,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
   enabled             = true
   is_ipv6_enabled     = true
+  http_version        = "http2and3"
   comment             = local.short
   default_root_object = "index.html"
 

--- a/deployment/terraform/site.tf
+++ b/deployment/terraform/site.tf
@@ -269,7 +269,7 @@ resource "aws_cloudwatch_log_group" "app" {
 resource "aws_cloudwatch_event_rule" "publish_site" {
   name                = "publish_site"
   description         = "Periodically build and publish the site"
-  schedule_expression = "cron(17,37,57 * * * ? *)"
+  schedule_expression = "cron(8,17,37,59 * * * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {

--- a/deployment/terraform/versions.tf
+++ b/deployment/terraform/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.15.0"
+      version = "~> 4.33.0"
     }
   }
 }

--- a/frontend/components/Layout.js
+++ b/frontend/components/Layout.js
@@ -1,11 +1,9 @@
-import DataQualityBanner from "./DataQualityBanner";
 import Header from "./Header";
 import Footer from "./Footer";
 
 export default function Layout({ children }) {
   return (
     <>
-      <DataQualityBanner />
       <Header />
       <main>{children}</main>
       <Footer />


### PR DESCRIPTION
## Overview

Two things, coming out of the discussion this morning with Annette:
- Removing the rainfall data warning banner.  We've resolved the issues with the forecast numbers (i.e. we've stopped showing past rainfall totals) and we've determined that we're using the MesoWest endpoint properly.  There's still the delayed-readings issue (see below) but the banner doesn't seem useful at this point.
- Adding a build and pushing the :57 build back to :59 to increase our chances of catching the hourly rainfall updates shortly after they show up on MesoWest.  They're taken at :53, so theoretically the :57 would always get them, but they've been showing up late.  We don't know exactly how late, but we think it's mostly around 10 minutes, so having extra builds in that time window should help avoid having the site spend a lot of time showing a 3-hour rainfall total that's actually a 2-hour total.

### Notes

When I run `terraform plan` on this branch it has one extra change--changing `http_version` from `http2and3` to `http2`.  Is setting it to `http2and3` a change we made manually that we should add to the terraform config?

## Testing Instructions

- View the site: no light blue banner at the top
- Run
  ```
  export AWS_PROFILE=sitka
  terraform init -backend-config="bucket=sitka-production-config-us-west-2"
  terraform plan
  ```
  It should show the schedule change and nothing else (except actually at the moment it also shows the other change noted above).

## Checklist

- [x] `./scripts/lint` runs without errors

