### PR TITLE
Switch mapbox token and style to Science Center account

### DIFF
--- a/frontend/components/Map.js
+++ b/frontend/components/Map.js
@@ -6,7 +6,8 @@ import "mapbox-gl/src/css/mapbox-gl.css";
 import legendStyles from "/styles/Legend.module.css";
 
 const Map = ({}) => {
-  mapboxgl.accessToken = "pk.eyJ1IjoibGtuYXJmIiwiYSI6IjhjbGg4RUkifQ.-lS6mAkmR3SVh-W4XwQElg";
+  mapboxgl.accessToken =
+    "pk.eyJ1Ijoic2l0a2FzY2llbmNlIiwiYSI6ImNsOHlsM3ZkYzBmcTEzb2s0MzdvM3NndG0ifQ.6v2_-rZ5P0K1F2B22p1G7w";
 
   const [mounted, setMounted] = useState(false);
 
@@ -16,7 +17,7 @@ const Map = ({}) => {
       const map = new mapboxgl.Map({
         cooperativeGestures: true,
         container: "map",
-        style: "mapbox://styles/lknarf/cl0pf3asg000114nt5jepzs6s",
+        style: "mapbox://styles/sitkascience/cl8ykz2x700bt15ql3qyenh0m",
         minZoom: 6,
         pitch: 60,
         bearing: 0,

--- a/frontend/components/Resources.js
+++ b/frontend/components/Resources.js
@@ -49,10 +49,10 @@ const Resources = ({ more }) => {
   ));
 
   return (
-    <div className={!more && styles.section}>
+    <div className={!more ? styles.section : ""}>
       {more ? (
         <div>
-          <hr style={{ margin: "var(--space-600) 0;" }} />
+          <hr style={{ margin: "var(--space-600) 0" }} />
           <h3 className={styles.heading}>More resources</h3>
         </div>
       ) : (


### PR DESCRIPTION
## Overview

Turns out we've been using the token and basemap layer from Jeff's account all this time. Which hasn't caused any problems, but it's not the right choice long-term...
Jeff made the style public and I cloned it into the Science Center's Mapbox account, so this switches the map component to use their token and layer.

This also fixes a few syntax things that were causing warnings from the compiler.  I don't know how long they've been around, and they weren't causing any trouble besides printing somewhat-inscrutable warnings in the terminal.  But the warnings were scrutable enough to make it easy to fix them, so I did.

## Testing Instructions

No visible change, except that if you load http://localhost:3008/areas-at-risk/ with debug tools open and look for requests in the network tab to `mapbox.com/styles`, you'll see that the URLs now include `sitkascience` and not `lknarf`.  And if you look at the terminal where you're running your dev server, you'll see a notable absence of compiler warnings.

## Checklist

- [x] `./scripts/lint` runs without errors

