### PR TITLE
Make nws alert banner more prominent

### DIFF
--- a/frontend/components/WeatherAdvisory.js
+++ b/frontend/components/WeatherAdvisory.js
@@ -8,7 +8,7 @@ const WeatherAdvisory = ({ permalink }) => {
     <a className={styles.banner} href={permalink}>
       <span className={styles.title}>
         <Icon name="circle-info" />
-        Weather alert from NWS
+        Weather advisory
       </span>
       <span className={styles.link}>Link</span>
     </a>

--- a/frontend/styles/WeatherAdvisory.module.css
+++ b/frontend/styles/WeatherAdvisory.module.css
@@ -1,6 +1,6 @@
 .banner {
   display: flex;
-  background-color: var(--mediumblue);
+  background-color: var(--lightblue);
   padding: var(--space-300);
   width: 100%;
   align-items: center;

--- a/frontend/styles/variables.css
+++ b/frontend/styles/variables.css
@@ -3,6 +3,7 @@
 
   --darkblue: #172a36;
   --mediumblue: #25465b;
+  --lightblue: #2667D9;
   --risk0: #068677;
   --risk1: #ecca51;
   --risk2: #d3354f;


### PR DESCRIPTION
## Overview

Makes color of NWS banner more prominent and updates copy.

Resolves #67 

### Demo

![demo-sitka-weather-banner](https://user-images.githubusercontent.com/16727618/196701645-acbbe7ae-ed3f-44b9-8755-0ae7f91dbf54.png)

### Notes

Simply updated the color and wording of the NWS weather alert banner.

## Testing Instructions

Verify appearance on mobile and desktop.

## Checklist

- [x] `./scripts/lint` runs without errors

