### PR TITLE
Change the chart label for "Current risk" to "Past 3 hours"

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -193,7 +193,7 @@ async function getPastRainfall() {
 
   return {
     timestamp: toLocalTimestamp(threeHourTimestamps[threeHourTimestamps.length - 1]),
-    dateTimeDetails: { label: "Current risk" },
+    dateTimeDetails: { label: "Past 3 hours" },
     precip,
     precipInches: mmToInches(precip),
     prevPrecip, // Needed for the look-back window of the first forecast period

--- a/frontend/pages/detail/[timestamp].js
+++ b/frontend/pages/detail/[timestamp].js
@@ -38,6 +38,8 @@ export async function getStaticProps({ params }) {
   const activeIndex = hours.findIndex((h) => params.timestamp === h.shortTimestamp);
   const activeData =
     params.timestamp === "current" ? current : hours[activeIndex] ? hours[activeIndex] : null;
+  const pageTitle =
+    params.timestamp === "current" ? "Current risk" : activeData.label ? activeData.label : null;
   const previousSlug =
     activeIndex === 0
       ? "current"
@@ -47,11 +49,11 @@ export async function getStaticProps({ params }) {
   const nextSlug = hours[activeIndex + 1] ? hours[activeIndex + 1].shortTimestamp : null;
 
   return {
-    props: { activeData, previousSlug, nextSlug },
+    props: { activeData, pageTitle, previousSlug, nextSlug },
   };
 }
 
-export default function Detail({ activeData, previousSlug, nextSlug }) {
+export default function Detail({ activeData, pageTitle, previousSlug, nextSlug }) {
   const historical = historicalData.map((d) => {
     return {
       x: d.day,
@@ -183,7 +185,7 @@ export default function Detail({ activeData, previousSlug, nextSlug }) {
 
   return (
     <Page
-      title={activeData.dateTimeDetails.label}
+      title={pageTitle}
       dateAbbr={activeData.dateTimeDetails.dateAbbr}
       dateFull={activeData.dateTimeDetails.dateFull}
       timeStart={activeData.dateTimeDetails.timeStart}
@@ -195,7 +197,7 @@ export default function Detail({ activeData, previousSlug, nextSlug }) {
     >
       <div>
         <Head>
-          <title>{activeData.dateTimeDetails.label} | Sitka Landslide Risk</title>
+          <title>{pageTitle} | Sitka Landslide Risk</title>
           <meta
             name="description"
             content={`Detailed landslide risk for ${activeData.dateTimeDetails.label}`}


### PR DESCRIPTION
## Overview

The historical rainfall chart doesn't actually graph the current risk, it graphs the most recent 3-hour rainfall. Which might be close enough, except that the current risk could be affected by earlier rainfall, in which case it could get confusing to see a low value on the chart labeled as a high risk.

So this changes the chart label to "Past 3 hours" (which also solves the problem of "current" possibly being interpreted as "current forecast for the next 3 hours").

It turns out that label gets set by `getRainfall.js`, since the labels for other values are datetimes that get processed/formatted in that script, so to reduce the amount of special-case handling in the front end, we just made "Current risk" a datetime label.  But of the four places it was used in the front end (chart, chart legend, window title, page title), only two should change. So this adds a bit of logic to make `timestamp.js` use a `pageTitle` prop that matches the datetime label for future periods but gets set to "Current risk" for the current period.

Resolves #76
This is also the last piece of #63

### Demo

![image](https://user-images.githubusercontent.com/6598836/198296524-488e4838-523f-4bd8-90c6-b448593b57c7.png)

## Testing Instructions

- Run `./scripts/server` to fetch/process rainfall data and start the dev server.
- Go to http://localhost:3008/detail/current/. It should still say "Current risk" in the window title and the title at the top of the page, but the label on the chart and in the legend should now say "Past 3 hours"
- Everything else should be the same

## Checklist

- [x] `./scripts/lint` runs without errors

