### PR TITLE
Update Synoptic token to new account

### DIFF
--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -8,7 +8,7 @@ const fs = require("fs");
 const EXAGGERATION_FACTOR = process.env.EXAGGERATION_FACTOR || 1;
 
 const MESOWEST_API = "https://api.synopticdata.com/v2";
-const MESOWEST_TOKEN = process.env.MESOWEST_TOKEN || "55162f4800b34421b4a4d87491709620";
+const MESOWEST_TOKEN = process.env.MESOWEST_TOKEN || "7af7d140d72d47a1991ded80a346234d";
 
 const NWS_API = "https://api.weather.gov/gridpoints/AJK/187,111";
 const STATION_LAT = 57.053;


### PR DESCRIPTION
## Overview

Synoptic agreed to let us use an "academic" account to get free access to the endpoint we need.  We made a new account, sitkalandslide@element84.com, and this changes the code to use a new token created on that account.

I ran `cipublish` from the branch, so this is already deployed and successfully fetching data in production.

### Notes

- It's nice to have a PR to mark the occasion, but I'm just going to merge this as soon as I open this, since there's not really anything to review and it's already live.
- The deployment process of this app is a bit unusual, and it would be nice to make it more in line with our usual scripts and processes, but then again it is documented and it's very simple, so it's probably not worth the effort.
- Similarly, it would be nice to provide this token from the environment—the code is set up to look there, but it's never actually provided, either in development or in production, so it always uses the hard-coded fallback—but under the current circumstances there's not really a practical benefit, so leaving it as it is makes sense.

## Testing Instructions

- You can run `yarn run get-data` (from `frontend/`) to confirm locally that the script that makes the API calls is working.

## Checklist

- [x] `./scripts/lint` runs without errors

