### PR TITLE
Add data attribution for Synoptic

### DIFF
--- a/frontend/components/LastUpdated.js
+++ b/frontend/components/LastUpdated.js
@@ -16,7 +16,8 @@ const LastUpdated = ({ update }) => {
       Last updated {time} with data from{" "}
       <a href="https://forecast.weather.gov/MapClick.php?lat=57.0531&lon=-135.33">
         National Weather Service
-      </a>
+      </a>{" "}
+      and <a href="https://synopticdata.com/">Synoptic Data</a>
     </div>
   );
 };

--- a/frontend/components/LastUpdated.js
+++ b/frontend/components/LastUpdated.js
@@ -14,10 +14,17 @@ const LastUpdated = ({ update }) => {
   return (
     <div className={styles.lastupdated}>
       Last updated {time} with data from{" "}
-      <a href="https://forecast.weather.gov/MapClick.php?lat=57.0531&lon=-135.33">
+      <a
+        href="https://forecast.weather.gov/MapClick.php?lat=57.0531&lon=-135.33"
+        target="_blank"
+        rel="noreferrer"
+      >
         National Weather Service
       </a>{" "}
-      and <a href="https://synopticdata.com/">Synoptic Data</a>
+      and{" "}
+      <a href="https://synopticdata.com/" target="_blank" rel="noreferrer">
+        Synoptic Data
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
## Overview

Adds "and Synoptic Data", with the name linked to synopticdata.com, to the "Last updated ___ ago with data from ..." line on the main page.

Resolves #82

### Demo

![image](https://github.com/azavea/sitka-landslide/assets/6598836/41332a20-d1af-4ff1-b927-65a783e7b453)

### Notes

I also added `target="_blank"` to both links so that people clicking them, perhaps thinking they'll be tool-tips, don't end up accidentally leaving the page.

I couldn't find any record of discussion about whether to make the attribution link open in a new tab or not.  It's possible I missed a discussion somewhere and making it a regular link was actually an intentional choice, but it seems more likely to me that it was an oversight.  After the second or third time I accidentally left the page while testing this change, I decided a new tab seemed like the right answer.

Also, according to `eslint`,
> Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers

so I added that as well.

## Testing Instructions

Just load up the dev server (`./scripts/update && ./scripts/server`), go to the main page (http://localhost:3008/), and there the new text and link will be.  Confirm that clicking either link takes you to the corresponding page, in a new tab or window (depending on how your browser is configured).

## Checklist

- [x] `./scripts/lint` runs without errors

