### PR TITLE
Copy rainfall.json to data/ in exported app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
         with:
           node-version: "16"
       - run: yarn install --frozen-lockfile
-      - run: yarn build
-      - run: yarn run next export
+      - run: yarn export
       - run: yarn lint
       - run: yarn run check-format
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ _Note:_ Some Mac users have gotten silent failures when the scripts try to activ
 
 Note that it is recommended to configure your editor to auto-format your code via Prettier on save.
 
+#### Emergency test version of rainfall.json
+
+The first thing that `scripts/server` does is get current data from the two weather APIs and write it to `frontend/data/rainfall.json` for the app to use.  If either of those APIs is down, that download will fail, and if you don't already have an old copy of `rainfall.json` locally, you won't be able to run the app.  To work around this infrequent but serious blocker without having to maintain a complete data fixture, we have the build include the `rainfall.json` file in the published assets.
+
+So when you the APIs are down, you should still be able to get the most recent successfully-retrieved data file at https://sitkalandslide.org/data/rainfall.json.
+
 ## Components
 
 - The front-end, a [Next.js](https://nextjs.org/docs) app. See [frontend](frontend).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
     "dev": "yarn get-data && next dev -p 3008",
     "analyze": "cross-env ANALYZE=true next build",
     "build": "yarn get-data && next build",
-    "export": "yarn build && next export",
+    "export": "yarn build && next export && cp data/rainfall.json out/data/rainfall.json",
     "start": "next start",
     "lint": "next lint",
     "check-format": "prettier --check '{pages,components}/*.{js,jsx,json,css}'",


### PR DESCRIPTION
## Overview

As we learned on 12/26 when the NWS API went down and there was no one around with an already-built app to help deal with it, it's very hard to run this app without a `rainfall.json` file, and very hard to get one unless both of the APIs are working. ([Slack discussion here](https://element84.slack.com/archives/C04UM8GQMRS/p1703609269721309))

This is a super-simple way to address that problem, by uploading the rainfall.json file for each build, so there will always be one on S3 that we can use. It might also be useful for facilitating debugging—if the site does something weird that seems data-related, we'll be able to grab the exact data file it was built with, rather than having to figure out how to reproduce the issue from new data.

### Notes

I'm not sure if this should be added to the README.  On the one hand it would be a nice thing to communicate, but on the other hand there's not really a section where it would fit at the moment, and my hope is that if future-us needs this, the `data` directory of the `sitkaproduction` S3 bucket would be one of the first places we think to look.

## Testing Instructions

- Activate nvm and yvm
- Remove an existing built site, if there is one (`rm -r frontend/out`)
- Change to the `frontend` directory and run `yarn export` to build the site
- Confirm that `out/data/rainfall.json` exists
- Confirm that the site works normally (isn't bothered by the rogue file in the diectory tree) ~by changing to the `out/` directory, running a local web server, and browsing around (e.g. `python3 -m http.server 9000`, or any other "serve this directory locally" utility)~ Update: I forgot this gets a staging deploy by Github Actions. Easier to look at https://staging.sitkalandslide.org/ to check the site...

## Checklist

- [x] `./scripts/lint` runs without errors

