### PR TITLE
Prepare for Repository Transfer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: "16"
       - run: yarn install --frozen-lockfile
       - run: yarn export
+        env:
+          MESOWEST_TOKEN: ${{ secrets.MESOWEST_TOKEN }}
       - run: yarn lint
       - run: yarn run check-format
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Currently this project consists only of a Next.js front-end. For local developme
 
 _Note:_ Some Mac users have gotten silent failures when the scripts try to activate nvm. If the scripts just exit without doing their job, it might help to upgrade or downgrade nvm to a version that's working for someone else.
 
+## Development
+
+To work on this application, you'll need an AWS access key pair for the Sitka AWS account. It should be configured as a profile named `sitka`.
+
 ### Getting started
 
 You will need to have `nvm` and `yvm` installed (see links in [Requirements](#requirements)) but the scripts take care of installing and activating the right versions.
@@ -61,21 +65,22 @@ Changes to any of the AWS components deployment via Terraform (see [Infrastructu
 
 ### Infrastructure
 
-You'll need the [Terraform CLI](https://learn.hashicorp.com/tutorials/terraform/install-cli) installed, with a version that satisfies the required version in [`versions.tf`](https://github.com/azavea/sitka-landslide/blob/develop/deployment/terraform/versions.tf).
-Since we currently have no tfvars file, there's nothing to download.
+You'll need the [Terraform CLI](https://learn.hashicorp.com/tutorials/terraform/install-cli) installed, with a version that satisfies the required version in [`versions.tf`](./deployment/terraform/versions.tf).
 
 From the `deployment/terraform` directory, first initialize and plan:
 
 ```
+rm *.tfplan
 export AWS_PROFILE=sitka
+aws s3 cp s3://sitka-production-config-us-west-2/sitka.tfvars sitka.tfvars
 terraform init -backend-config="bucket=sitka-production-config-us-west-2"
-terraform plan
+terraform plan -var-file="sitka.tfvars" -out="sitka.tfplan"
 ```
 
 Check the output to make sure it's going to do what you think it should, and no more. Then apply:
 
 ```
-terraform apply
+terraform apply sitka.tfplan
 ```
 
 Check the output of that command to make sure it did what you expected.

--- a/deployment/terraform/.gitignore
+++ b/deployment/terraform/.gitignore
@@ -1,0 +1,4 @@
+.terraform/
+.terraform.lock.hcl
+*.tfplan
+*.tfvars

--- a/deployment/terraform/site.tf
+++ b/deployment/terraform/site.tf
@@ -166,7 +166,12 @@ resource "aws_ecs_task_definition" "build" {
     "image": "${aws_ecr_repository.default.repository_url}:latest",
     "essential": true,
     "portMappings": [],
-    "environment": [],
+    "environment": [
+      {
+        "name": "MESOWEST_TOKEN",
+        "value": "${var.MESOWEST_TOKEN}"
+      }
+    ],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -286,8 +291,8 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
     enable_ecs_managed_tags = true
 
     network_configuration {
-      subnets          = ["subnet-0c809320a8958a62e"] #Manually got ID
-      security_groups  = ["sg-09f6958f76126065e"]     #Manually got ID
+      subnets          = ["subnet-0c809320a8958a62e"] # Manually got ID
+      security_groups  = ["sg-09f6958f76126065e"]     # Manually got ID
       assign_public_ip = true
     }
   }
@@ -295,7 +300,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
 
 # Add S3 Endpoint
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id       = "vpc-0782aa50f85e73afd" #Manually got existing VPC ID
+  vpc_id       = "vpc-0782aa50f85e73afd" # Manually got existing VPC ID
   service_name = "com.amazonaws.us-west-2.s3"
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -21,3 +21,7 @@ variable "domain_name" {
   default = "sitkalandslide.org"
   type    = string
 }
+
+variable "MESOWEST_TOKEN" {
+  type    = string
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 # Install packages
-COPY package.json yarn.lock ./
+COPY package.json yarn.lock .env ./
 RUN yarn install --frozen-lockfile && yarn cache clean
 
 # Copy code. Annoyingly, you can't copy specific directories all at once. Directory args are

--- a/frontend/data/getRainfall.js
+++ b/frontend/data/getRainfall.js
@@ -3,12 +3,17 @@ const axiosRetry = require("axios-retry");
 const { DateTime } = require("luxon");
 const fs = require("fs");
 
+// Load development environment variables
+if (process.env.NODE_ENV !== 'production') {
+  require('dotenv').config();
+}
+
 // For debugging: a multiplier applied to rainfall amounts to get the results up into an
 // interesting range. Something in the 8-15 range will usually do the trick.
 const EXAGGERATION_FACTOR = process.env.EXAGGERATION_FACTOR || 1;
 
 const MESOWEST_API = "https://api.synopticdata.com/v2";
-const MESOWEST_TOKEN = process.env.MESOWEST_TOKEN || "7af7d140d72d47a1991ded80a346234d";
+const MESOWEST_TOKEN = process.env.MESOWEST_TOKEN;
 
 const NWS_API = "https://api.weather.gov/gridpoints/AJK/187,111";
 const STATION_LAT = 57.053;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@next/bundle-analyzer": "^12.1.0",
     "critters": "^0.0.16",
     "cross-env": "^7.0.3",
+    "dotenv": "^16.5.0",
     "eslint": "8.7.0",
     "eslint-config-next": "12.0.9",
     "fs": "0.0.1-security",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1241,6 +1241,11 @@ domutils@^2.8.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
+dotenv@^16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.5.0.tgz#092b49f25f808f020050051d1ff258e404c78692"
+  integrity sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==
+
 duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"

--- a/scripts/setup
+++ b/scripts/setup
@@ -13,7 +13,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
+        # Download .env file if missing
+        if [ ! -f "./frontend/.env" ]; then
+            aws --profile sitka s3 cp s3://sitka-production-config-us-west-2/.env frontend/.env
+        fi
+
+        # Install dependencies and prepare project
         ./scripts/update
     fi
 fi
-


### PR DESCRIPTION
## Overview

This removes the previously hard coded `MESOWEST_TOKEN`. Now this is read from the environment. For devlopment, this is picked up from the .env file, which is downloaded from S3 during `setup`. For deployments. this is added to .tfvars which should be downloaded from S3 before running terraform commands. It is also added to the ECS task's environment, so when new images are baked and deployed, they have it already.

README is updated accordingly.

This has been deployed to production.

~~Before this can be merged, we must also update the CI workflow to read in this variable from the repository secrets. I don't have permissions to view or add new secrets just yet, so waiting for that before merging this.~~ This is now done as well.

I've also deleted the old MESOWEST token from https://customer.synopticdata.com/credentials/, so it can no longer be used.

Resolves #97 

## Testing Instructions

- Check https://staging.sitkalandslide.org/ to ensure it works
- Check https://sitkalandslide.org/ to ensure it works

## Checklist

- [x] `./scripts/lint` runs without errors

